### PR TITLE
use scatter interval prefix (when supplied) in output files

### DIFF
--- a/tests/data/0000-scattered.interval_list
+++ b/tests/data/0000-scattered.interval_list
@@ -1,0 +1,3 @@
+@HD	VN:1.6
+@SQ	SN:chr11	LN:537000	M5:61481174fa6fb38c44f2027f467f95c3	UR:file:/Users/junjun/A.ARGO/git/gatk-tools/tests/reference/tiny-grch38-chr11-530001-537000.fa
+chr11	530001	532333	+	.

--- a/tools/gatk-mutect2/gatk-mutect2.cwl
+++ b/tools/gatk-mutect2/gatk-mutect2.cwl
@@ -5,7 +5,7 @@ id: gatk-mutect2
 requirements:
 - class: ShellCommandRequirement
 - class: DockerRequirement
-  dockerPull: 'quay.io/icgc-argo/gatk-mutect2:gatk-mutect2.4.1.3.0-1.1'
+  dockerPull: 'quay.io/icgc-argo/gatk-mutect2:gatk-mutect2.4.1.3.0-1.3'
 
 baseCommand: [ 'gatk-mutect2.py' ]
 
@@ -64,17 +64,17 @@ outputs:
   unfiltered_vcf:
     type: File
     outputBinding:
-      glob: $(inputs.output_vcf)
+      glob: "*$(inputs.output_vcf)"
     secondaryFiles: [.tbi]
   mutect_stats:
     type: File
     outputBinding:
-      glob: $(inputs.output_vcf).stats
+      glob: "*$(inputs.output_vcf).stats"
   bam_output:
     type: ['null', File]
     outputBinding:
-      glob: $(inputs.bam_output)
+      glob: "*$(inputs.bam_output)"
   f1r2_counts:
     type: ['null', File]
     outputBinding:
-      glob: $(inputs.f1r2_tar_gz)
+      glob: "*$(inputs.f1r2_tar_gz)"

--- a/tools/gatk-mutect2/gatk-mutect2.cwl
+++ b/tools/gatk-mutect2/gatk-mutect2.cwl
@@ -47,7 +47,7 @@ inputs:
     type: File?
     inputBinding:
       prefix: -L
-  bam_output:
+  bam_output_name:
     type: string?
     inputBinding:
       prefix: --bam-output
@@ -73,7 +73,7 @@ outputs:
   bam_output:
     type: ['null', File]
     outputBinding:
-      glob: "*$(inputs.bam_output)"
+      glob: "*$(inputs.bam_output_name)"
     secondaryFiles: [.bai]
   f1r2_counts:
     type: ['null', File]

--- a/tools/gatk-mutect2/gatk-mutect2.cwl
+++ b/tools/gatk-mutect2/gatk-mutect2.cwl
@@ -74,6 +74,7 @@ outputs:
     type: ['null', File]
     outputBinding:
       glob: "*$(inputs.bam_output)"
+    secondaryFiles: [.bai]
   f1r2_counts:
     type: ['null', File]
     outputBinding:

--- a/tools/gatk-mutect2/gatk-mutect2.py
+++ b/tools/gatk-mutect2/gatk-mutect2.py
@@ -30,6 +30,10 @@ def main():
 
     args = parser.parse_args()
 
+    output_prefix = ''
+    if args.intervals:
+        output_prefix = os.path.basename(args.intervals).split('.')[0] + '.'
+
     if not args.output_vcf.endswith('.vcf.gz'):
         sys.exit('Usage: output VCF file name must end with ".vcf.gz"')
 
@@ -39,8 +43,8 @@ def main():
     if args.f1r2_tar_gz and not args.f1r2_tar_gz.endswith('.tar.gz'):
         sys.exit('Usage: f1r2_tar_gz output file name must end with ".tar.gz"')
 
-    cmd = 'gatk --java-options "-Xmx%sm" Mutect2 -R %s -O %s -I %s' % (
-            args.jvm_mem, args.ref_fa, args.output_vcf, args.tumour_reads
+    cmd = 'gatk --java-options "-Xmx%sm" Mutect2 -R %s -O %s%s -I %s' % (
+            args.jvm_mem, args.ref_fa, output_prefix, args.output_vcf, args.tumour_reads
         )
 
     if args.normal_reads:
@@ -61,10 +65,10 @@ def main():
         cmd = cmd + ' -L %s' % args.intervals
 
     if args.bam_output:
-        cmd = cmd + ' --bam-output %s' % args.bam_output
+        cmd = cmd + ' --bam-output %s%s' % (output_prefix, args.bam_output)
 
     if args.f1r2_tar_gz:
-        cmd = cmd + ' --f1r2-tar-gz %s' % args.f1r2_tar_gz
+        cmd = cmd + ' --f1r2-tar-gz %s%s' % (output_prefix, args.f1r2_tar_gz)
 
     p, success = None, True
     try:

--- a/tools/gatk-mutect2/tests/test-job-with-interval.yaml
+++ b/tools/gatk-mutect2/tests/test-job-with-interval.yaml
@@ -1,0 +1,15 @@
+intervals:
+  class: File
+  path: data/0000-scattered.interval_list
+tumour_reads:
+  class: File
+  path: data/HCC1143-mini-T/8f879c15-14da-593d-bb76-db866f81ab3a.6.20190927.wgs.grch38.bam
+normal_reads:
+  class: File
+  path: data/HCC1143_BL-mini-N/cfa409d0-3236-5f07-8634-a2c0de74c8f2.5.20190927.wgs.grch38.bam
+ref_fa:
+  class: File
+  path: reference/tiny-grch38-chr11-530001-537000.fa
+output_vcf: HCC1143.mutect2.vcf.gz
+bam_output: HCC1143.bamout.bam
+f1r2_tar_gz: HCC1143.f1r2.tar.gz

--- a/tools/gatk-mutect2/tests/test-job-with-interval.yaml
+++ b/tools/gatk-mutect2/tests/test-job-with-interval.yaml
@@ -11,5 +11,5 @@ ref_fa:
   class: File
   path: reference/tiny-grch38-chr11-530001-537000.fa
 output_vcf: HCC1143.mutect2.vcf.gz
-bam_output: HCC1143.bamout.bam
+bam_output_name: HCC1143.bamout.bam
 f1r2_tar_gz: HCC1143.f1r2.tar.gz

--- a/tools/gatk-mutect2/tests/test-job.yaml
+++ b/tools/gatk-mutect2/tests/test-job.yaml
@@ -8,5 +8,5 @@ ref_fa:
   class: File
   path: reference/tiny-grch38-chr11-530001-537000.fa
 output_vcf: HCC1143.mutect2.vcf.gz
-bam_output: HCC1143.bamout.bam
+bam_output_name: HCC1143.bamout.bam
 f1r2_tar_gz: HCC1143.f1r2.tar.gz


### PR DESCRIPTION
this will prevent output file name conflict from different scatter tasks